### PR TITLE
feat: Add basic navigation menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-dom": "^17.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-icons": "^4.2.0",
     "react-scripts": "4.0.3",
     "sass": "^1.36.0",
     "typescript": "^4.1.2"

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,6 +1,17 @@
+html {
+  background-color: blue; // debug colour
+}
+body {
+  background-color: green; // debug colour
+}
+
+#root {
+  background-color: red; // debug colour
+}
+
 .App {
   color: white;
-  background-color: #242738;
+  background-color: #242738c5; // debug colour (added transparency), should move up to html element
 
   min-width: 180px;
   min-height: 100vh;

--- a/src/App.scss
+++ b/src/App.scss
@@ -7,6 +7,20 @@ body {
 
 #root {
   background-color: red; // debug colour
+
+  /*
+  Establishes a viewport scrolling container:
+
+  - `position: absolute` removes the dependency of html and body element parent dimensions for % units.
+
+  - `overflow-y: auto` ensures any overflowing content will be scrolled from this layer,
+  keeping the bg color consistent to this layer.
+  (prevents a height delta causing height mismatch/leaking other layers bg colour).
+  */
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
 }
 
 .App {
@@ -14,7 +28,24 @@ body {
   background-color: #242738c5; // debug colour (added transparency), should move up to html element
 
   min-width: 180px;
-  min-height: 100vh;
+  // Use up height of parent element (viewport height) as a minimum if content is below that.
+  min-height: 100%;
+
+  /*
+  Don't `overflow-y: auto` here as the min-width of this layer can mean the
+  vertical scrollbar will be hidden if the viewport width is too small,
+  requiring horizontal scrolling to realize a vertical scrollbar is present..
+
+  `overflow: hidden` can be used here like below with `height: 100%` for
+  preventing scrolling when an overlay (eg open mobile nav menu) is active.
+
+  However as we can't use `overflow-y: auto` as well on the same layer,
+  this will result in always resetting/losing the scroll position which is
+  undesirable. That is caused by `overflow: hidden` toggling affecting the
+  parent (`#root`) overflow scrollbar/height, causing it to lose the scroll state.
+  */
+  // height: 100%;
+  // overflow-y: hidden;
 
   display: flex;
   flex-direction: column;

--- a/src/App.scss
+++ b/src/App.scss
@@ -26,4 +26,11 @@ which is sized and stretched to fill the viewport without issues that vh/vw have
   justify-content: flex-start;
 
   color: white;
+
+  /*
+  navbar menu content relies on this to exceed viewport height/width if scrollbars are present.
+  if omitting have menu content div use `min-width: 180px`, otherwise it's width as
+  shown by bg colour will be viewport only, not full width when horizontally scrollable.
+  */
+  position: relative;
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,16 +1,12 @@
-@import-normalize;
-
-*, *::after, *::before {
-  box-sizing: border-box;
-}
-
 .App {
   color: white;
   background-color: #242738;
 
+  min-width: 180px;
   min-height: 100vh;
+
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,22 +1,14 @@
 html {
-  background-color: blue; // debug colour
-}
-body {
-  background-color: green; // debug colour
+  background-color: rgb(36 39 56);
 }
 
+/*
+- Ensures any vertical overflowing content will be scrolled from this layer,
+which is sized and stretched to fill the viewport without issues that vh/vw have.
+- Child element .App will size based on #root as it's parent.
+- `min-width` must not be set on this element due to overflow behaviour rendering scrollbars.
+*/
 #root {
-  background-color: red; // debug colour
-
-  /*
-  Establishes a viewport scrolling container:
-
-  - `position: absolute` removes the dependency of html and body element parent dimensions for % units.
-
-  - `overflow-y: auto` ensures any overflowing content will be scrolled from this layer,
-  keeping the bg color consistent to this layer.
-  (prevents a height delta causing height mismatch/leaking other layers bg colour).
-  */
   position: absolute;
   width: 100%;
   height: 100%;
@@ -24,31 +16,14 @@ body {
 }
 
 .App {
-  color: white;
-  background-color: #242738c5; // debug colour (added transparency), should move up to html element
-
   min-width: 180px;
-  // Use up height of parent element (viewport height) as a minimum if content is below that.
+  // Uses viewport height (from #root) unless content height exceeds it.
   min-height: 100%;
-
-  /*
-  Don't `overflow-y: auto` here as the min-width of this layer can mean the
-  vertical scrollbar will be hidden if the viewport width is too small,
-  requiring horizontal scrolling to realize a vertical scrollbar is present..
-
-  `overflow: hidden` can be used here like below with `height: 100%` for
-  preventing scrolling when an overlay (eg open mobile nav menu) is active.
-
-  However as we can't use `overflow-y: auto` as well on the same layer,
-  this will result in always resetting/losing the scroll position which is
-  undesirable. That is caused by `overflow: hidden` toggling affecting the
-  parent (`#root`) overflow scrollbar/height, causing it to lose the scroll state.
-  */
-  // height: 100%;
-  // overflow-y: hidden;
 
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
+
+  color: white;
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -23,9 +23,9 @@ which is sized and stretched to fill the viewport without issues that vh/vw have
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
 
   color: white;
+  padding: 8px;
 
   /*
   navbar menu content relies on this to exceed viewport height/width if scrollbars are present.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import './App.scss';
-import Form from './components/cc-form'
+import './App.scss'
+import Page from './views/register-cc'
+import NavBar from './components/navbar'
 
 function App() {
   return (
     <div className="App">
-      <Form />
+      <NavBar />
+      <Page />
     </div>
   )
 }

--- a/src/components/cc-form/styles.module.scss
+++ b/src/components/cc-form/styles.module.scss
@@ -9,9 +9,8 @@
   grid-template-columns: 1fr;
 
   box-sizing: border-box;
-  min-width: 180px;
   max-width: 360px;
-  padding: 8px;
+  padding: 0;
 
   line-height: 1.5;
 

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react'
+import styles from './styles.module.scss'
+
+export const NavMenu: React.FC<HTMLProps> = () => {
+  const [isOpen, setIsOpen] = useState(false)
+  const toggleMenu = () => setIsOpen(!isOpen)
+
+  return (
+    <header className={styles.header}>
+      <h1>{isOpen ? "Menu" : "Register Card Form"}</h1>
+      <nav className={styles.navbar}>
+        <button onClick={toggleMenu}>
+          {isOpen ? "<=" : "Open"}
+        </button>
+        <div style={{display: isOpen ? "block" : "none" }}>
+          <p>This is menu content.</p>
+        </div>
+      </nav>
+    </header>
+  )
+}
+
+type HTMLProps = React.HTMLAttributes<HTMLElement>
+
+export default NavMenu

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { FaHamburger, FaArrowLeft } from 'react-icons/fa';
 import styles from './styles.module.scss'
 
 export const NavMenu: React.FC<HTMLProps> = () => {
@@ -10,7 +11,10 @@ export const NavMenu: React.FC<HTMLProps> = () => {
       <h1>{isOpen ? "Menu" : "Register Card Form"}</h1>
       <nav className={styles.navbar}>
         <button onClick={toggleMenu}>
-          {isOpen ? "<=" : "Open"}
+        {isOpen
+          ? <FaArrowLeft aria-hidden="true" />
+          : <FaHamburger aria-hidden="true" />
+        }
         </button>
         <div style={{display: isOpen ? "block" : "none" }}>
           <p>This is menu content.</p>

--- a/src/components/navbar/styles.module.scss
+++ b/src/components/navbar/styles.module.scss
@@ -1,5 +1,5 @@
 .header {
-  // position: relative; // important for the menu content div styles
+  // position: relative; // Required for menu content div `Approach #2` styles
   width: 100%;
   padding: 8px;
 
@@ -27,6 +27,7 @@
 
 .navbar {
   > button {
+    // Style reset
     background:transparent;
     border: none;
     cursor: pointer;
@@ -34,29 +35,30 @@
     margin: 0;
     padding: 0;
 
-    // Could alternatively use 1.5em
-    width: 3rem;
-    height: 3rem;
-    // Affects size of icon and this button, which all use em for sizing
+    // Width and Height are sized to scale proportionally to the SVG icon size (1em).
+    // Adjusting font-size will scale all dimensions accordingly.
     font-size: 2rem;
+    width: 1.5em;
+    height: 1.5em;
     // Affects vertical alignment of svg icons
     line-height: 0;
 
     // Circle button style with a box-shadow as a border (that doesn't interfere with layout)
-    background-color: rgba(0, 0, 0, 0.25);
-    box-shadow: 0 0 0 2px hsla(170deg, 90%, 70%, 0.5);
     border-radius: 50%;
-
+    background-color: rgba(0, 0, 0, 0.25);
     &:hover, &:active {
       background-color: rgba(0, 0, 0, 0.5);
     }
 
+    --border: 0 0 0 2px hsla(170deg, 90%, 70%, 0.5);
+    --border-focus: inset var(--border), 0 0 0 4px dodgerblue;
+    box-shadow: var(--border);
     &:focus {
       outline: none;
-      box-shadow: inset 0 0 0 2px hsla(170deg, 90%, 70%, 0.5), 0 0 0 4px dodgerblue;
+      box-shadow: var(--border-focus);
 
       // Remove focus-ring for non-keyboard triggered focus
-      &:not(:focus-visible) { box-shadow: 0 0 0 2px hsla(170deg, 90%, 70%, 0.5); }
+      &:not(:focus-visible) { box-shadow: var(--border); }
     }
   }
 
@@ -93,7 +95,7 @@
     bottom: 0; // Stretch to bottom of viewport exactly.
     margin: 0;
 
-    // Required if not using `position: relative` on .App, but using approach #3 above:
+    // Required if not using `position: relative` on .App, but using `Approach #3` above:
     // min-width: 180px;
 
     > p {

--- a/src/components/navbar/styles.module.scss
+++ b/src/components/navbar/styles.module.scss
@@ -1,7 +1,6 @@
 .header {
-  position: relative;
+  // position: relative; // important for the menu content div styles
   width: 100%;
-  height: 48px;
   padding: 8px;
 
   display: flex;
@@ -9,13 +8,15 @@
   justify-content: space-between; // left align the menu toggle, right align the h1
   gap: 8px;
 
-  background-color: blue;
+  background-color: hsl(162deg 65% 45%);
 
   > h1 {
     order: 1; // swap visual order with nav toggle button
     margin: 0;
-    font-size: 1rem; //16px
     transition: font-size 0.3s;
+
+    font-size: 1.2rem;
+    text-align: right;
 
     @media (min-width: 360px) {
       font-size: 28px;
@@ -59,19 +60,45 @@
   }
 
   > div {
-    position: absolute;
-    top: 100%; // height of header (relies on header having `position: relative`)
     left: 0;
 
     width: 100%;
     margin: 0;
     padding: 0;
 
+    // Debug colour for experimenting with layout approaches.
     background-color: green;
+    // Same as bg colour for `html`; hides the page content below by covering it.
+    background-color: rgb(36 39 56);
+
+    /* === Approach #1 === */
+    // Seems "hacky" with no apparent control regarding the hidden scrollbar issue:
+    position: fixed; // Note dimensions can overlap/cover any visible scrollbars and prevents interaction with them.
+    // height: 100%; // extends to full viewport height
+    margin-top: 16px; // 8px padding (nav around button) + 8px added margin (after nav height)
+
+    /* === Approach #2 === */
+    // This works well if you don't need to extend the height to bottom of viewport
+    // Relies on header element having `position: relative`.
+    position: absolute;
+    top: 100%;
+    margin-top: 8px; // 8px added margin (after nav height)
+
+    /* === Approach #3 === */
+    // This version of absolute requires header element to not have `position: relative`
+    // So that it can properly be contained within the viewport bounds.
+    position: absolute;
+    top: 80px; // 64px header element + 16px margin (8px top and bottom)
+    bottom: 0; // Stretch to bottom of viewport exactly.
+    margin: 0;
+
+    // Required if not using `position: relative` on .App, but using approach #3 above:
+    // min-width: 180px;
 
     > p {
       margin: 0;
       padding: 8px;
+      text-align: center;
     }
   }
 }

--- a/src/components/navbar/styles.module.scss
+++ b/src/components/navbar/styles.module.scss
@@ -31,10 +31,7 @@
 
   > div {
     position: absolute;
-    // earlier approach:
-    // top: 48px;
-    // better? uses 100% of navbar height (header element which is `position: relative`)
-    top: 100%;
+    top: 100%; // height of header (relies on header having `position: relative`)
     left: 0;
 
     width: 100%;

--- a/src/components/navbar/styles.module.scss
+++ b/src/components/navbar/styles.module.scss
@@ -25,8 +25,37 @@
 
 .navbar {
   > button {
+    background:transparent;
+    border: none;
     cursor: pointer;
-    height: 32px;
+    color: inherit;
+    margin: 0;
+    padding: 0;
+
+    // Could alternatively use 1.5em
+    width: 3rem;
+    height: 3rem;
+    // Affects size of icon and this button, which all use em for sizing
+    font-size: 2rem;
+    // Affects vertical alignment of svg icons
+    line-height: 0;
+
+    // Circle button style with a box-shadow as a border (that doesn't interfere with layout)
+    background-color: rgba(0, 0, 0, 0.25);
+    box-shadow: 0 0 0 2px hsla(170deg, 90%, 70%, 0.5);
+    border-radius: 50%;
+
+    &:hover, &:active {
+      background-color: rgba(0, 0, 0, 0.5);
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: inset 0 0 0 2px hsla(170deg, 90%, 70%, 0.5), 0 0 0 4px dodgerblue;
+
+      // Remove focus-ring for non-keyboard triggered focus
+      &:not(:focus-visible) { box-shadow: 0 0 0 2px hsla(170deg, 90%, 70%, 0.5); }
+    }
   }
 
   > div {

--- a/src/components/navbar/styles.module.scss
+++ b/src/components/navbar/styles.module.scss
@@ -1,49 +1,43 @@
 .header {
   position: relative;
   width: 100%;
+  height: 48px;
+  padding: 8px;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between; // left align the menu toggle, right align the h1
+  gap: 8px;
+
   background-color: blue;
 
   > h1 {
-    display: block;
-    
-    position: absolute;
-    width: 100%;
-    height: 48px;
+    order: 1; // swap visual order with nav toggle button
     margin: 0;
-    padding: 0;
-    padding-right: 8px;
-
-    // At <210 px when menu is open, the h1 text starts to get clipped by the button
-    // Introducing padding-left allows for breaking h1 to two lines, but line-height
-    // results in overflowing the navbar height and with large gap between lines.
-    // Would require another media query to properly resolve..
     font-size: 1rem; //16px
-    line-height: 48px;
-    text-align: right;
+    transition: font-size 0.3s;
 
-    @media (min-width: 240px) {
-      // Roughly scales between the two sizes,
-      // calc can't use `*` or `/` to calculate a ratio based on viewport width..
-      font-size: 8vw;
-    }
     @media (min-width: 360px) {
-      font-size: 2rem; //32px
+      font-size: 28px;
     }
   }
 }
 
 .navbar {
-  // Required for making the button not blocked by the h1 layer.
-  position: relative;
-
   > button {
     cursor: pointer;
     height: 32px;
-    margin: 8px;
   }
 
-  // Content when revealed will push page content down.
   > div {
+    position: absolute;
+    // earlier approach:
+    // top: 48px;
+    // better? uses 100% of navbar height (header element which is `position: relative`)
+    top: 100%;
+    left: 0;
+
+    width: 100%;
     margin: 0;
     padding: 0;
 

--- a/src/components/navbar/styles.module.scss
+++ b/src/components/navbar/styles.module.scss
@@ -1,5 +1,7 @@
+@use './styles/button';
+@use './styles/navmenu';
+
 .header {
-  // position: relative; // Required for menu content div `Approach #2` styles
   width: 100%;
   padding: 8px;
 
@@ -27,81 +29,10 @@
 
 .navbar {
   > button {
-    // Style reset
-    background:transparent;
-    border: none;
-    cursor: pointer;
-    color: inherit;
-    margin: 0;
-    padding: 0;
-
-    // Width and Height are sized to scale proportionally to the SVG icon size (1em).
-    // Adjusting font-size will scale all dimensions accordingly.
-    font-size: 2rem;
-    width: 1.5em;
-    height: 1.5em;
-    // Affects vertical alignment of svg icons
-    line-height: 0;
-
-    // Circle button style with a box-shadow as a border (that doesn't interfere with layout)
-    border-radius: 50%;
-    background-color: rgba(0, 0, 0, 0.25);
-    &:hover, &:active {
-      background-color: rgba(0, 0, 0, 0.5);
-    }
-
-    --border: 0 0 0 2px hsla(170deg, 90%, 70%, 0.5);
-    --border-focus: inset var(--border), 0 0 0 4px dodgerblue;
-    box-shadow: var(--border);
-    &:focus {
-      outline: none;
-      box-shadow: var(--border-focus);
-
-      // Remove focus-ring for non-keyboard triggered focus
-      &:not(:focus-visible) { box-shadow: var(--border); }
-    }
+    @include button.menu();
   }
 
   > div {
-    left: 0;
-
-    width: 100%;
-    margin: 0;
-    padding: 0;
-
-    // Debug colour for experimenting with layout approaches.
-    background-color: green;
-    // Same as bg colour for `html`; hides the page content below by covering it.
-    background-color: rgb(36 39 56);
-
-    /* === Approach #1 === */
-    // Seems "hacky" with no apparent control regarding the hidden scrollbar issue:
-    position: fixed; // Note dimensions can overlap/cover any visible scrollbars and prevents interaction with them.
-    // height: 100%; // extends to full viewport height
-    margin-top: 16px; // 8px padding (nav around button) + 8px added margin (after nav height)
-
-    /* === Approach #2 === */
-    // This works well if you don't need to extend the height to bottom of viewport
-    // Relies on header element having `position: relative`.
-    position: absolute;
-    top: 100%;
-    margin-top: 8px; // 8px added margin (after nav height)
-
-    /* === Approach #3 === */
-    // This version of absolute requires header element to not have `position: relative`
-    // So that it can properly be contained within the viewport bounds.
-    position: absolute;
-    top: 80px; // 64px header element + 16px margin (8px top and bottom)
-    bottom: 0; // Stretch to bottom of viewport exactly.
-    margin: 0;
-
-    // Required if not using `position: relative` on .App, but using `Approach #3` above:
-    // min-width: 180px;
-
-    > p {
-      margin: 0;
-      padding: 8px;
-      text-align: center;
-    }
+    @include navmenu.content();
   }
 }

--- a/src/components/navbar/styles.module.scss
+++ b/src/components/navbar/styles.module.scss
@@ -9,6 +9,7 @@
   gap: 8px;
 
   background-color: hsl(162deg 65% 45%);
+  border-radius: 4px;
 
   > h1 {
     order: 1; // swap visual order with nav toggle button

--- a/src/components/navbar/styles.module.scss
+++ b/src/components/navbar/styles.module.scss
@@ -1,0 +1,57 @@
+.header {
+  position: relative;
+  width: 100%;
+  background-color: blue;
+
+  > h1 {
+    display: block;
+    
+    position: absolute;
+    width: 100%;
+    height: 48px;
+    margin: 0;
+    padding: 0;
+    padding-right: 8px;
+
+    // At <210 px when menu is open, the h1 text starts to get clipped by the button
+    // Introducing padding-left allows for breaking h1 to two lines, but line-height
+    // results in overflowing the navbar height and with large gap between lines.
+    // Would require another media query to properly resolve..
+    font-size: 1rem; //16px
+    line-height: 48px;
+    text-align: right;
+
+    @media (min-width: 240px) {
+      // Roughly scales between the two sizes,
+      // calc can't use `*` or `/` to calculate a ratio based on viewport width..
+      font-size: 8vw;
+    }
+    @media (min-width: 360px) {
+      font-size: 2rem; //32px
+    }
+  }
+}
+
+.navbar {
+  // Required for making the button not blocked by the h1 layer.
+  position: relative;
+
+  > button {
+    cursor: pointer;
+    height: 32px;
+    margin: 8px;
+  }
+
+  // Content when revealed will push page content down.
+  > div {
+    margin: 0;
+    padding: 0;
+
+    background-color: green;
+
+    > p {
+      margin: 0;
+      padding: 8px;
+    }
+  }
+}

--- a/src/components/navbar/styles/_button.scss
+++ b/src/components/navbar/styles/_button.scss
@@ -1,0 +1,35 @@
+@mixin menu() {
+  // Style reset
+  background:transparent;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  margin: 0;
+  padding: 0;
+
+  // Width and Height are sized to scale proportionally to the SVG icon size (1em).
+  // Adjusting font-size will scale all dimensions accordingly.
+  font-size: 2rem;
+  width: 1.5em;
+  height: 1.5em;
+  // Affects vertical alignment of svg icons
+  line-height: 0;
+
+  // Circle button style with a box-shadow as a border (that doesn't interfere with layout)
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.25);
+  &:hover, &:active {
+    background-color: rgba(0, 0, 0, 0.5);
+  }
+
+  --border: 0 0 0 2px hsla(170deg, 90%, 70%, 0.5);
+  --border-focus: inset var(--border), 0 0 0 4px dodgerblue;
+  box-shadow: var(--border);
+  &:focus {
+    outline: none;
+    box-shadow: var(--border-focus);
+
+    // Remove focus-ring for non-keyboard triggered focus
+    &:not(:focus-visible) { box-shadow: var(--border); }
+  }
+}

--- a/src/components/navbar/styles/_navmenu.scss
+++ b/src/components/navbar/styles/_navmenu.scss
@@ -1,0 +1,46 @@
+@mixin content() {
+  left: 0;
+
+  width: 100%;
+  margin: 0;
+  padding: 0;
+
+  // Debug colour for experimenting with layout approaches.
+  background-color: green;
+  // Same as bg colour for `html`; hides the page content below by covering it.
+  background-color: rgb(36 39 56);
+
+  /* === Approach #1 === */
+  // Seems "hacky" with no apparent control regarding the hidden scrollbar issue:
+  position: fixed; // Note dimensions can overlap/cover any visible scrollbars and prevents interaction with them.
+  // height: 100%; // extends to full viewport height
+  margin-top: 16px; // 8px padding (nav around button) + 8px added margin (after nav height)
+
+  /* === Approach #2 === */
+  // This works well if you don't need to extend the height to bottom of viewport
+  // Relies on header element having `position: relative`.
+  position: absolute;
+  top: 100%;
+  margin-top: 8px; // 8px added margin (after nav height)
+  // Required for menu content div `Approach #2` styles
+  // @at-root .header {
+  //   position: relative;
+  // }
+
+  /* === Approach #3 === */
+  // This version of absolute requires header element to not have `position: relative`
+  // So that it can properly be contained within the viewport bounds.
+  position: absolute;
+  top: 80px; // 64px header element + 16px margin (8px top and bottom)
+  bottom: 0; // Stretch to bottom of viewport exactly.
+  margin: 0;
+
+  // Required if not using `position: relative` on .App, but using `Approach #3` above:
+  // min-width: 180px;
+
+  > p {
+    margin: 0;
+    padding: 8px;
+    text-align: center;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
+@import-normalize;
+
+*, *::after, *::before {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;

--- a/src/views/register-cc.tsx
+++ b/src/views/register-cc.tsx
@@ -1,0 +1,11 @@
+import Form from '../components/cc-form'
+import styles from './styles.module.scss'
+
+export const Page = () => (
+  <div className={styles.page}>
+    <p>Welcome Brennan!</p>
+    <Form />
+  </div>
+)
+
+export default Page

--- a/src/views/styles.module.scss
+++ b/src/views/styles.module.scss
@@ -2,4 +2,14 @@
   > p {
     text-align: center;
   }
+
+  flex-grow: 1;
+  
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  @media (min-width: 360px) {
+    justify-content: center;
+  }
 }

--- a/src/views/styles.module.scss
+++ b/src/views/styles.module.scss
@@ -1,15 +1,5 @@
 .page {
-  /*
-  Earlier approach with nav header element used `position: absolute`
-  changed to `position: relative`, so normal document flow doesn't require
-  maintaining the navbar height in sync, however will be required if using a
-  fixed header that reveals on scroll.
-  */
-  // margin-top: 48px; // navbar is absolute
-
   > p {
     text-align: center;
-    // height: 2000px; // debug height for testing overflow scrolling
-    background-color: orange; // debug colour
   }
 }

--- a/src/views/styles.module.scss
+++ b/src/views/styles.module.scss
@@ -9,6 +9,7 @@
 
   > p {
     text-align: center;
+    // height: 2000px; // debug height for testing overflow scrolling
     background-color: orange; // debug colour
   }
 }

--- a/src/views/styles.module.scss
+++ b/src/views/styles.module.scss
@@ -1,5 +1,14 @@
 .page {
+  /*
+  Earlier approach with nav header element used `position: absolute`
+  changed to `position: relative`, so normal document flow doesn't require
+  maintaining the navbar height in sync, however will be required if using a
+  fixed header that reveals on scroll.
+  */
+  // margin-top: 48px; // navbar is absolute
+
   > p {
-      text-align: center;
+    text-align: center;
+    background-color: orange; // debug colour
   }
 }

--- a/src/views/styles.module.scss
+++ b/src/views/styles.module.scss
@@ -1,0 +1,5 @@
+.page {
+  > p {
+      text-align: center;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9026,6 +9026,11 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
+react-icons@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.2.0.tgz#6dda80c8a8f338ff96a1851424d63083282630d0"
+  integrity sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==
+
 react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
Meeting test requirements:

- [x] Clicking the burger (menu) icon displays the nav menu (_as depicted in the LoFi_).
- [x] Clicking the back icon button displays the "Register Card Form" page.

Most commits have messages detailing CSS changes as styling is iterated on and layout concerns addressed, notably viewport height and overflow scrolling consistency between mobile and desktop browsers.