### PR TITLE
feat: a11y pass

### DIFF
--- a/src/components/cc-form/components/Error.tsx
+++ b/src/components/cc-form/components/Error.tsx
@@ -1,25 +1,34 @@
 import { ZodError } from 'zod'
 import type { CreditCard } from '../schema'
 
+/*
+- Extra wrapping div is to accomodate browsers like Firefox which do not announce the initial
+content when appended to the DOM.
+- Toggling display property instead of visibility has no difference on Firefox,
+but Chrome will not announce content properly with visibility toggle,
+especially if inline styled elements are present.
+*/
 export const List: React.FC<ErrorListProps> = ({className, hasErrors, children}) => (
-  <div className={className} style={!hasErrors ? {display: "none"} : undefined}>
-    <h2 id="aria_errorlist" aria-label="Error,">Error</h2>
-    <p id="aria_errormsg">
-      <em>Unable to submit details due to the following:</em>
-    </p>
-    <ul aria-live="polite" aria-relevant="additions text">
-      {children}
-    </ul>
+  <div className={className} role="alert" aria-live="assertive">
+    <div style={{ display: hasErrors ? "block" : "none" }}>
+      <h2 id="aria_errorlist" aria-label="Error,">Error</h2>
+      <p id="aria_errormsg">
+        <em>Unable to submit details due to the following:</em>
+      </p>
+      <ul>
+        {children}
+      </ul>
+    </div>
   </div>
 )
 
-export const Item: React.FC<ErrorItemProps> = ({errors, id, label}) => {
+export const Item: React.FC<ErrorItemProps> =  ({errors, id, label}) => {
   const error = errors?.issues.filter(err => err.path.includes(id))
 
   return error && error.length > 0 ? (
-    <li>
-      <span id={`err_${id}_label`}>{label}</span>
-      {error.map(err =>
+    <li aria-atomic="true">
+      <span id={`err_${id}_label`} aria-describedby={`aria_errorlist`}>{label}</span>
+      {error?.map(err =>
       <span id={`err_${id}`}>{err.message}</span>
       )}
     </li>

--- a/src/components/cc-form/components/Error.tsx
+++ b/src/components/cc-form/components/Error.tsx
@@ -3,9 +3,11 @@ import type { CreditCard } from '../schema'
 
 export const List: React.FC<ErrorListProps> = ({className, hasErrors, children}) => (
   <div className={className} style={!hasErrors ? {display: "none"} : undefined}>
-    <h2>Error</h2>
-    <p><em>Unable to submit details due to the following:</em></p>
-    <ul>
+    <h2 id="aria_errorlist" aria-label="Error,">Error</h2>
+    <p id="aria_errormsg">
+      <em>Unable to submit details due to the following:</em>
+    </p>
+    <ul aria-live="polite" aria-relevant="additions text">
       {children}
     </ul>
   </div>
@@ -16,9 +18,9 @@ export const Item: React.FC<ErrorItemProps> = ({errors, id, label}) => {
 
   return error && error.length > 0 ? (
     <li>
-      <span>{label}</span>
+      <span id={`err_${id}_label`}>{label}</span>
       {error.map(err =>
-      <span>{err.message}</span>
+      <span id={`err_${id}`}>{err.message}</span>
       )}
     </li>
   ) : null

--- a/src/components/cc-form/components/Input.tsx
+++ b/src/components/cc-form/components/Input.tsx
@@ -21,7 +21,7 @@ export const Input: React.FC<InputProps> = ({ id, label, hasError, ...props }) =
 type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   id: string
   label?: string
-  hasError: boolean
+  hasError?: boolean
 }
 
 export default Input

--- a/src/components/cc-form/components/Input.tsx
+++ b/src/components/cc-form/components/Input.tsx
@@ -1,6 +1,6 @@
 import styles from '../styles.module.scss'
 
-export const Input: React.FC<InputProps> = ({ id, label, ...props }) => (
+export const Input: React.FC<InputProps> = ({ id, label, hasError, ...props }) => (
   <>
     {label && (<label htmlFor={id}>{label}:</label>)}
     <input
@@ -10,6 +10,8 @@ export const Input: React.FC<InputProps> = ({ id, label, ...props }) => (
       type="text"
       inputMode="tel"
       autoComplete={id.replace(/_/g, "-")}
+      aria-describedby={hasError ? `aria_errorlist err_${id}` : undefined}
+      aria-invalid={hasError || undefined}
       required
       {...props}
     />
@@ -19,6 +21,7 @@ export const Input: React.FC<InputProps> = ({ id, label, ...props }) => (
 type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   id: string
   label?: string
+  hasError: boolean
 }
 
 export default Input

--- a/src/components/cc-form/components/Submit.tsx
+++ b/src/components/cc-form/components/Submit.tsx
@@ -1,0 +1,34 @@
+/* 
+- `aria-disabled` is only announced by TalkBack on focus of the submit button.
+The soft keyboard "done" button announces "Go" as aural feedback, regardless of
+this aria attribute. Unable to inform the listener, they need to change focus to the
+submit button or navigate the error list.
+Note this attribute is only meant to announce a disabled state, even when still functional.
+That was intentional, as the `disabled` attribute prevents focus causing a11y confusion.
+
+- `aria-describedby` ensures the correct announcement order to the listener when
+focusing on the submit button.
+*/
+export const Submit: React.FC<SubmitProps> = ({className, hasErrors }) => (
+  <button
+    className={className}
+    type="submit"
+    aria-disabled={hasErrors || undefined}
+    aria-describedby={hasErrors ? describeErrors : undefined}
+  >
+    Submit
+  </button>
+)
+
+type SubmitProps = {
+  className: string
+  hasErrors: boolean
+}
+
+// I'm too tired to handle this properly and meet the deadline..sorry :(
+// Used by the submit button receiving focus to describe any errors present.
+const describeErrors = "aria_errorlist aria_errormsg " +
+  "err_cc_number_label err_cc_number " +
+  "err_cc_exp_month_label err_cc_exp_month " +
+  "err_cc_exp_year_label err_cc_exp_year " +
+  "err_cc_csc_label err_cc_csc"

--- a/src/components/cc-form/components/index.ts
+++ b/src/components/cc-form/components/index.ts
@@ -1,2 +1,3 @@
 export { Error } from './Error'
 export { Input } from './Input'
+export { Submit } from './Submit'

--- a/src/components/cc-form/index.tsx
+++ b/src/components/cc-form/index.tsx
@@ -1,5 +1,5 @@
 import styles from './styles.module.scss'
-import { Error, Input} from './components'
+import { Error, Input, Submit } from './components'
 import { CreditCard } from './schema'
 import { useForm, onValid, onInvalid } from './submitLogic'
 
@@ -27,14 +27,14 @@ export const Form = () => {
         <Input
           id="cc_exp_month"
           maxLength={2}
-          aria-label="Month, Format: 2 digits"
+          aria-label="Month, Format: 2 digits."
           hasError={hasError("cc_exp_month")}
         />
         <span>/</span>
         <Input
           id="cc_exp_year"
           maxLength={2}
-          aria-label="Year, Format: 2 digits"
+          aria-label="Year, Format: 2 digits."
           hasError={hasError("cc_exp_year")}
         />
       </fieldset>
@@ -48,7 +48,7 @@ export const Form = () => {
         />
       </div>
 
-      <button className={styles.submit} type="submit">Submit</button>
+      <Submit className={styles.submit} hasErrors={hasErrors} />
 
       <Error.List className={styles.errors} hasErrors={hasErrors}>
         <Error.Item id="cc_number"    label="Card Number"   errors={errors} />

--- a/src/components/cc-form/index.tsx
+++ b/src/components/cc-form/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import styles from './styles.module.scss'
 import { Error, Input} from './components'
-import { CreditCard } from './schema'
+import { _zCreditCard, CreditCard } from './schema'
 import { useForm, onValid, onInvalid } from './submitLogic'
 
 export const Form = () => {
@@ -11,16 +11,15 @@ export const Form = () => {
   } = useForm<CreditCard>()
 
   // All this to get an error status bool per field:
-  const [hasError, setError] = useState(fieldStatus)
+  type Fields = Record<any, never> | Record<keyof CreditCard, boolean>
+  const [hasError, setError] = useState<Fields>({})
+
   useEffect(() => {
-    setError(
-      Object.keys(fieldStatus).reduce((fields, key) => {
-        return {
-          ...fields,
-          [key]: errors?.issues.some(err => err.path.includes(key))
-        }
-      }, fieldStatus)
-    )
+    const fields: any = {}
+    Object.keys(_zCreditCard.shape).forEach(key => {
+      fields[key] = errors?.issues.some(err => err.path.includes(key))
+    })
+    setError(fields)
   }, [errors?.issues])
 
   const hasErrors = isSubmitted && !isValid
@@ -71,13 +70,6 @@ export const Form = () => {
       </Error.List>
     </form>
   )
-}
-
-const fieldStatus = {
-  cc_number: false,
-  cc_exp_month: false,
-  cc_exp_year: false,
-  cc_csc: false,
 }
 
 export default Form

--- a/src/components/cc-form/index.tsx
+++ b/src/components/cc-form/index.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react'
 import styles from './styles.module.scss'
 import { Error, Input} from './components'
 import { CreditCard } from './schema'
@@ -9,23 +10,55 @@ export const Form = () => {
     formState: { errors, isValid, isSubmitted },
   } = useForm<CreditCard>()
 
+  // All this to get an error status bool per field:
+  const [hasError, setError] = useState(fieldStatus)
+  useEffect(() => {
+    setError(
+      Object.keys(fieldStatus).reduce((fields, key) => {
+        return {
+          ...fields,
+          [key]: errors?.issues.some(err => err.path.includes(key))
+        }
+      }, fieldStatus)
+    )
+  }, [errors?.issues])
+
   const hasErrors = isSubmitted && !isValid
 
   return (
     <form className={styles.form} onSubmit={handleSubmit(onValid, onInvalid)}>
       <div className={styles.cc_number}>
-        <Input id="cc_number" label="Card Number" />
+        <Input
+          id="cc_number"
+          label="Card Number"
+          hasError={hasError.cc_number}
+        />
       </div>
 
       <fieldset className={styles.cc_exp}>
         <legend>Expiry Date (MM / YY):</legend>
-        <Input id="cc_exp_month" maxLength={2} />
+        <Input
+          id="cc_exp_month"
+          maxLength={2}
+          aria-label="Month, Format: 2 digits"
+          hasError={hasError.cc_exp_month}
+        />
         <span>/</span>
-        <Input id="cc_exp_year" maxLength={2} />
+        <Input
+          id="cc_exp_year"
+          maxLength={2}
+          aria-label="Year, Format: 2 digits"
+          hasError={hasError.cc_exp_year}
+        />
       </fieldset>
 
       <div className={styles.cc_csc}>
-        <Input id="cc_csc" maxLength={4} label="Security Code" />
+        <Input
+          id="cc_csc"
+          maxLength={4}
+          label="Security Code"
+          hasError={hasError.cc_csc}
+        />
       </div>
 
       <button className={styles.submit} type="submit">Submit</button>
@@ -38,6 +71,13 @@ export const Form = () => {
       </Error.List>
     </form>
   )
+}
+
+const fieldStatus = {
+  cc_number: false,
+  cc_exp_month: false,
+  cc_exp_year: false,
+  cc_csc: false,
 }
 
 export default Form

--- a/src/components/cc-form/index.tsx
+++ b/src/components/cc-form/index.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect } from 'react'
 import styles from './styles.module.scss'
 import { Error, Input} from './components'
-import { _zCreditCard, CreditCard } from './schema'
+import { CreditCard } from './schema'
 import { useForm, onValid, onInvalid } from './submitLogic'
 
 export const Form = () => {
@@ -10,18 +9,7 @@ export const Form = () => {
     formState: { errors, isValid, isSubmitted },
   } = useForm<CreditCard>()
 
-  // All this to get an error status bool per field:
-  type Fields = Record<any, never> | Record<keyof CreditCard, boolean>
-  const [hasError, setError] = useState<Fields>({})
-
-  useEffect(() => {
-    const fields: any = {}
-    Object.keys(_zCreditCard.shape).forEach(key => {
-      fields[key] = errors?.issues.some(err => err.path.includes(key))
-    })
-    setError(fields)
-  }, [errors?.issues])
-
+  const hasError = (id: keyof CreditCard) => errors?.issues.some(err => err.path.includes(id))
   const hasErrors = isSubmitted && !isValid
 
   return (
@@ -30,7 +18,7 @@ export const Form = () => {
         <Input
           id="cc_number"
           label="Card Number"
-          hasError={hasError.cc_number}
+          hasError={hasError("cc_number")}
         />
       </div>
 
@@ -40,14 +28,14 @@ export const Form = () => {
           id="cc_exp_month"
           maxLength={2}
           aria-label="Month, Format: 2 digits"
-          hasError={hasError.cc_exp_month}
+          hasError={hasError("cc_exp_month")}
         />
         <span>/</span>
         <Input
           id="cc_exp_year"
           maxLength={2}
           aria-label="Year, Format: 2 digits"
-          hasError={hasError.cc_exp_year}
+          hasError={hasError("cc_exp_year")}
         />
       </fieldset>
 
@@ -56,7 +44,7 @@ export const Form = () => {
           id="cc_csc"
           maxLength={4}
           label="Security Code"
-          hasError={hasError.cc_csc}
+          hasError={hasError("cc_csc")}
         />
       </div>
 

--- a/src/components/cc-form/styles.module.scss
+++ b/src/components/cc-form/styles.module.scss
@@ -69,6 +69,6 @@ div.cc_csc {
 }
 
 
-div.errors {
+div.errors > div {
   @include errors.styles();
 }

--- a/src/components/cc-form/styles/_errors.scss
+++ b/src/components/cc-form/styles/_errors.scss
@@ -17,6 +17,7 @@
 
   > ul {
     list-style: none;
+    margin: 0;
     padding: 0;
 
     > li {

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -10,18 +10,30 @@ export const NavMenu: React.FC<HTMLProps> = () => {
     <header className={styles.header}>
       <h1>{isOpen ? "Menu" : "Register Card Form"}</h1>
       <nav className={styles.navbar}>
-        <button onClick={toggleMenu}>
-        {isOpen
-          ? <FaArrowLeft aria-hidden="true" />
-          : <FaHamburger aria-hidden="true" />
-        }
-        </button>
+        <MenuToggle isOpen={isOpen} onClick={toggleMenu} />
         <div style={{display: isOpen ? "block" : "none" }}>
           <p>This is menu content.</p>
         </div>
       </nav>
     </header>
   )
+}
+
+const MenuToggle: React.FC<ButtonProps> = ({isOpen, onClick, className}) => (
+  <button
+    onClick={onClick}
+    aria-label={`${isOpen ? "Close" : "Open"} navigation menu`}
+    aria-expanded={isOpen}
+  >
+    {isOpen
+      ? <FaArrowLeft aria-hidden="true" />
+      : <FaHamburger aria-hidden="true" />
+    }
+  </button>
+)
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  isOpen: boolean
 }
 
 type HTMLProps = React.HTMLAttributes<HTMLElement>


### PR DESCRIPTION
### Navbar

- `aria-label` for clearer intent.
- `aria-expanded` is advised for a `<button>` in `<nav>` with the menu content (typically a `<ul>` list of links) following immediately after it. The dynamic `aria-label` diminishes the value a little bit?

### Inputs:

- Expiry date month and year fields have `aria-label` specific to them now since the two fields share the common `<legend>` "label", the announcement is presumably nicer than hearing "Expiry Date, em em why why" (which won't be heard if navigating form inputs directly via the "next" button on the mobile soft keyboard.
- `aria-invalid` is used if an error is present which may be helpful, unable to confirm on Android Chrome and Firefox as Talkback doesn't seem to support this attribute. It apparently has in the past ([with Talkback 8.2, Chrome 85, Android 10](https://a11ysupport.io/tests/tech__aria__aria-invalid/aria__aria-invalid_attribute/convey_value_true/talkback/and_chr)), [I raised an issue](https://github.com/accessibilitysupported/a11ysupport.io/issues/178) to update results.
- `aria-describedby` additionally appends the related error message to the input description on focus.

### Error List

- `aria-live` region should announce errors as they are appended, however on Firefox (Android with Talkback) this is announcing the entire list content, presumably because of how the a11y tree is handled with sibling content, it's not related to lists specifically. Unlike Chrome, `role="alert"` has no effect in my testing, but it's equivalent `aria-live="assertive"` does work on Firefox, so both have been used.
- `aria-atomic` on error messages ensures they're fully announced. Android Chrome with Talkback unfortunately not only announces the updates in random order, even with `aria-atomic` updates announced remain mixed with no hierarchy making an `aria-live` region less useful.
- `aria-relevant` which defaults to "additions text" seems to be ignored/unsupported by Talkback and these two browsers on Android, I lack access to other AT software to know if there is any value from it. Originally I wanted to just focus on "additions" as errors were appended interactively.

### Submit button

- `aria-describedby` will announce the active errors listed in correct order when the button is focused on, not sure if this is a good idea or helpful at all to an AT user.
- `aria-disabled` isn't serving much value currently, but seems to be advised (_perhaps more useful without the `aria-describedby` approach_).

---

I noticed various other gotchas with Talkback behaviour and inconsistency between Android Chrome and Firefox support with this AT, made some notes and will look into tidying those up to add to this repo later on :)

I also noticed with some annoucements for example with inputs that have an error with `aria-describedby` can be a bit too fast between transitions without any punctuation to better separate distinct context. Some aria labels append `.` or `,` at the end to improve on that, but it seems a little "hacky".