### PR TITLE
chore: Minor refactorings

### DIFF
--- a/src/components/cc-form/components/Error.tsx
+++ b/src/components/cc-form/components/Error.tsx
@@ -23,14 +23,12 @@ export const List: React.FC<ErrorListProps> = ({ className, hasErrors, children 
 )
 
 export const Item: React.FC<ErrorItemProps> = ({ errors, id, label }) => {
-  const error = errors?.issues.filter(err => err.path.includes(id))
+  const error = errors?.issues.filter(err => err.path.includes(id))[0]
 
-  return error && error.length > 0 ? (
+  return error ? (
     <li aria-atomic="true">
       <span id={`err_${id}_label`} aria-describedby={`aria_errorlist`}>{label}</span>
-      {error?.map(err =>
-      <span id={`err_${id}`}>{err.message}</span>
-      )}
+      <span id={`err_${id}`}>{error.message}</span>
     </li>
   ) : null
 }

--- a/src/components/cc-form/components/Error.tsx
+++ b/src/components/cc-form/components/Error.tsx
@@ -8,7 +8,7 @@ content when appended to the DOM.
 but Chrome will not announce content properly with visibility toggle,
 especially if inline styled elements are present.
 */
-export const List: React.FC<ErrorListProps> = ({className, hasErrors, children}) => (
+export const List: React.FC<ErrorListProps> = ({ className, hasErrors, children }) => (
   <div className={className} role="alert" aria-live="assertive">
     <div style={{ display: hasErrors ? "block" : "none" }}>
       <h2 id="aria_errorlist" aria-label="Error,">Error</h2>
@@ -22,7 +22,7 @@ export const List: React.FC<ErrorListProps> = ({className, hasErrors, children})
   </div>
 )
 
-export const Item: React.FC<ErrorItemProps> =  ({errors, id, label}) => {
+export const Item: React.FC<ErrorItemProps> = ({ errors, id, label }) => {
   const error = errors?.issues.filter(err => err.path.includes(id))
 
   return error && error.length > 0 ? (

--- a/src/components/cc-form/components/Input.tsx
+++ b/src/components/cc-form/components/Input.tsx
@@ -1,4 +1,5 @@
 import styles from '../styles.module.scss'
+import type { CreditCard } from '../schema'
 
 export const Input: React.FC<InputProps> = ({ id, label, hasError, ...props }) => (
   <>
@@ -18,10 +19,69 @@ export const Input: React.FC<InputProps> = ({ id, label, hasError, ...props }) =
   </>
 )
 
+export const ExpiryDate: React.FC<ExpiryDateProps> = ({ className, month, year }) => (
+  <fieldset className={className || styles.cc_exp}>
+    <legend>Expiry Date (MM / YY):</legend>
+    {month}
+    <span>/</span>
+    {year}
+  </fieldset>
+)
+
+export const CardNumber: React.FC<FixedInputProps> = ({ className, hasError }) => (
+  <div className={className || styles.cc_number}>
+    <Input
+      id="cc_number"
+      label="Card Number"
+      hasError={hasError("cc_number")}
+    />
+  </div>
+)
+
+export const ExpMonth: React.FC<FixedInputProps> = ({ hasError }) => (
+  <Input
+    id="cc_exp_month"
+    aria-label="Month, Format: 2 digits."
+    maxLength={2}
+    hasError={hasError("cc_exp_month")}
+  />
+)
+
+export const ExpYear: React.FC<FixedInputProps> = ({ hasError }) => (
+  <Input
+    id="cc_exp_year"
+    aria-label="Year, Format: 2 digits."
+    maxLength={2}
+    hasError={hasError("cc_exp_year")}
+  />
+)
+
+export const SecurityCode: React.FC<FixedInputProps> = ({ className, hasError }) => (
+  <div className={className || styles.cc_csc}>
+    <Input
+      id="cc_csc"
+      label="Security Code"
+      maxLength={4}
+      hasError={hasError("cc_csc")}
+    />
+  </div>
+)
+
 type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
-  id: string
+  id: keyof CreditCard
   label?: string
   hasError?: boolean
+}
+
+type ExpiryDateProps = {
+  className?: string
+  month: React.ReactNode
+  year: React.ReactNode
+}
+
+type FixedInputProps = {
+  className?: string
+  hasError: (id: keyof CreditCard) => boolean | undefined
 }
 
 export default Input

--- a/src/components/cc-form/components/index.ts
+++ b/src/components/cc-form/components/index.ts
@@ -1,3 +1,3 @@
 export { Error } from './Error'
-export { Input } from './Input'
+export * as Inputs from './Input'
 export { Submit } from './Submit'

--- a/src/components/cc-form/index.tsx
+++ b/src/components/cc-form/index.tsx
@@ -1,5 +1,5 @@
 import styles from './styles.module.scss'
-import { Error, Input, Submit } from './components'
+import { Error, Inputs, Submit } from './components'
 import { CreditCard } from './schema'
 import { useForm, onValid, onInvalid } from './submitLogic'
 
@@ -14,39 +14,14 @@ export const Form = () => {
 
   return (
     <form className={styles.form} onSubmit={handleSubmit(onValid, onInvalid)}>
-      <div className={styles.cc_number}>
-        <Input
-          id="cc_number"
-          label="Card Number"
-          hasError={hasError("cc_number")}
-        />
-      </div>
+      <Inputs.CardNumber hasError={hasError} />
 
-      <fieldset className={styles.cc_exp}>
-        <legend>Expiry Date (MM / YY):</legend>
-        <Input
-          id="cc_exp_month"
-          maxLength={2}
-          aria-label="Month, Format: 2 digits."
-          hasError={hasError("cc_exp_month")}
-        />
-        <span>/</span>
-        <Input
-          id="cc_exp_year"
-          maxLength={2}
-          aria-label="Year, Format: 2 digits."
-          hasError={hasError("cc_exp_year")}
-        />
-      </fieldset>
+      <Inputs.ExpiryDate
+        month={<Inputs.ExpMonth hasError={hasError} />}
+        year ={<Inputs.ExpYear  hasError={hasError} />}
+      />
 
-      <div className={styles.cc_csc}>
-        <Input
-          id="cc_csc"
-          maxLength={4}
-          label="Security Code"
-          hasError={hasError("cc_csc")}
-        />
-      </div>
+      <Inputs.SecurityCode hasError={hasError} />
 
       <Submit className={styles.submit} hasErrors={hasErrors} />
 

--- a/src/components/cc-form/index.tsx
+++ b/src/components/cc-form/index.tsx
@@ -13,17 +13,19 @@ export const Form = () => {
   const hasErrors = isSubmitted && !isValid
 
   return (
-    <form className={styles.form} onSubmit={handleSubmit(onValid, onInvalid)}>
-      <Inputs.CardNumber hasError={hasError} />
+    <div className={styles.formWrapper}>
+      <form className={styles.form} onSubmit={handleSubmit(onValid, onInvalid)}>
+        <Inputs.CardNumber hasError={hasError} />
 
-      <Inputs.ExpiryDate
-        month={<Inputs.ExpMonth hasError={hasError} />}
-        year ={<Inputs.ExpYear  hasError={hasError} />}
-      />
+        <Inputs.ExpiryDate
+          month={<Inputs.ExpMonth hasError={hasError} />}
+          year ={<Inputs.ExpYear  hasError={hasError} />}
+        />
 
-      <Inputs.SecurityCode hasError={hasError} />
+        <Inputs.SecurityCode hasError={hasError} />
 
-      <Submit className={styles.submit} hasErrors={hasErrors} />
+        <Submit className={styles.submit} hasErrors={hasErrors} />
+      </form>
 
       <Error.List className={styles.errors} hasErrors={hasErrors}>
         <Error.Item id="cc_number"    label="Card Number"   errors={errors} />
@@ -31,7 +33,7 @@ export const Form = () => {
         <Error.Item id="cc_exp_year"  label="Expiry Year"   errors={errors} />
         <Error.Item id="cc_csc"       label="Security Code" errors={errors} />
       </Error.List>
-    </form>
+    </div>
   )
 }
 

--- a/src/components/cc-form/schema.ts
+++ b/src/components/cc-form/schema.ts
@@ -61,9 +61,9 @@ export const _zCreditCard = z.object({
 })
 
 // Presently this schema has differing input and output types due to zStringNumber type above
-type zInput  = z.input<typeof _zCreditCard>
+// type zInput  = z.input<typeof _zCreditCard>
 type zOutput = z.output<typeof _zCreditCard>
-type zIO = zInput | zOutput
+// type zIO = zInput | zOutput
 
 const isNotExpired: SuperRefinement<zOutput> = ({cc_exp_month: m, cc_exp_year: y}, ctx) => {
   if (y === currentYear && m <= currentMonth) {

--- a/src/components/cc-form/schema.ts
+++ b/src/components/cc-form/schema.ts
@@ -6,7 +6,9 @@ const currentYear  = new Date().getUTCFullYear() - 2000
 
 
 // Custom Validations:
+// `.refine(inRange(x,y), err)` is like `.min(x, err).max(y, err)`, but works after `transform()`
 const inRange    = (x: number, y: number) => (n: number) => (n >= x && n <= y)
+// `inRangeStr` is unnecessary and could instead be `zDigitString.min(x, err).max(y, err)`
 const inRangeStr = (x: number, y: number) => (s: string) => inRange(x, y)(s.length)
 const r_isDigits = /^[0-9]+$/
 
@@ -15,8 +17,8 @@ const r_isDigits = /^[0-9]+$/
 const errorRangeMonth = "Must be a number between 1 and 12"
 const errorMinYear    = "Value should not be in the past"
 const errorRangeCSC   = "Value should be 3 digits; 4 if American Express"
-const errorNaN        = "Value should be a number"
 const errorDigits     = "Expected only numbers"
+const errorNaN        = "Value should be a number"
 
 
 // Custom Types:
@@ -24,13 +26,13 @@ const zDigitString = z.string().regex(r_isDigits, errorDigits)
 const zStringNumber = zDigitString.transform(s => parseInt(s))
 
 // Zod maintainer mentioned this type alias to provide a more generic type signature
-// A future release should export it :)
+// A future release should export it: https://github.com/colinhacks/zod/pull/576 :)
 type SuperRefinement<T> = (
   val: T,
   ctx: z.RefinementCtx
 ) => void
 
-// A `min()` implementation for zDigitString to use as if it were a `z.number()`
+// A `min(n, err)` implementation for zDigitString to use as if it were a `z.number().min(n, err)`
 type zMin<T> = (min: T, message?: string) => SuperRefinement<T>
 const min: zMin<number> = (min, message) => (val, ctx) => {
   if (val < min) {

--- a/src/components/cc-form/styles.module.scss
+++ b/src/components/cc-form/styles.module.scss
@@ -2,6 +2,36 @@
 @use './styles/input';
 @use './styles/submit';
 
+.formWrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  // Unable to make the separator adapt to with flex-wrap
+  // flex-wrap: wrap;
+
+  @media (max-width: 759.9px) {
+    // Placed here instead of error list style since it's strictly layout style.
+    // Targets the inner div since the outer one cannot be hidden for a11y reasons.
+    // > *:not(:first-child) > div {
+    > div.errors > div {
+      margin-top: 16px;
+      padding-top: 16px;
+      border-top: 2px solid hsl(240deg 15% 25%);
+    }
+  }
+
+  @media (min-width: 760px) {
+    flex-direction: row;
+
+    > div.errors > div {
+      margin-left: 16px;
+      padding-left: 16px;
+      border-left: 2px solid hsl(240deg 15% 25%);
+    }
+  }
+}
+
 .form {
   display: grid;
   align-items: end;
@@ -26,9 +56,6 @@
     }
     > div.cc_csc {
       grid-column: span 4;
-    }
-    > div.errors {
-      grid-column: span 10;
     }
   }
 

--- a/src/components/cc-form/styles/_errors.scss
+++ b/src/components/cc-form/styles/_errors.scss
@@ -1,6 +1,6 @@
 @mixin styles() {
   font-size: 1rem;
-  line-height: inherit;
+  line-height: 1.5;
 
   > h2 {
     margin: 0;

--- a/src/components/cc-form/styles/_submit.scss
+++ b/src/components/cc-form/styles/_submit.scss
@@ -3,9 +3,10 @@ button.submit {
   cursor: pointer;
   transition: all 0.3s ease;
 
-  margin-top: auto;
-  padding: 8px 32px;
+  // Useful if you want to push it down to the edge of the viewport when the leement has excess height available
+  // margin-top: auto;
 
+  padding: 8px 32px;
   width: 100%;
   height: 2.8rem;
 


### PR DESCRIPTION
- Extracted each form input into it's own component. Unsure how beneficial this is since it's mostly hiding information/noise away. A little better for the compound ExpiryDate component readability.
- Wrapped the `<form>` in another div so that the ErrorList component could be split out beside it and better adapt to the viewport responsively. Unsure if this improved UX at all for wider viewports.
- Schema was tidied up. Settled on `isNotExpired()` typing approach, sharing a type alias with another super refinement method. Error messages aren't required to be an object; so changed to plain strings.
- Fix: The minimum expiry year validation is back to being a field level validation instead of compound level.
- Error Item only handles a single message per item as intended by the design.