### PR TITLE
feat: Adopt a context for error state

### DIFF
--- a/src/components/cc-form/components/Error.tsx
+++ b/src/components/cc-form/components/Error.tsx
@@ -1,5 +1,5 @@
-import { ZodError } from 'zod'
 import type { CreditCard } from '../schema'
+import { useErrorContext } from '../submitLogic'
 
 /*
 - Extra wrapping div is to accomodate browsers like Firefox which do not announce the initial
@@ -22,8 +22,9 @@ export const List: React.FC<ErrorListProps> = ({ className, hasErrors, children 
   </div>
 )
 
-export const Item: React.FC<ErrorItemProps> = ({ errors, id, label }) => {
-  const error = errors?.issues.filter(err => err.path.includes(id))[0]
+export const Item: React.FC<ErrorItemProps> = ({ id, label }) => {
+  const field = useErrorContext()
+  const error = field.getError(id)
 
   return error ? (
     <li aria-atomic="true">
@@ -41,7 +42,6 @@ type ErrorListProps = {
 type ErrorItemProps = {
   id: keyof CreditCard
   label: string
-  errors?: ZodError
 }
 
 export const Error = {List, Item}

--- a/src/components/cc-form/components/Input.tsx
+++ b/src/components/cc-form/components/Input.tsx
@@ -1,23 +1,29 @@
 import styles from '../styles.module.scss'
 import type { CreditCard } from '../schema'
+import { useErrorContext } from '../submitLogic'
 
-export const Input: React.FC<InputProps> = ({ id, label, hasError, ...props }) => (
-  <>
-    {label && (<label htmlFor={id}>{label}:</label>)}
-    <input
-      className={styles.input}
-      id={id}
-      name={id}
-      type="text"
-      inputMode="tel"
-      autoComplete={id.replace(/_/g, "-")}
-      aria-describedby={hasError ? `aria_errorlist err_${id}` : undefined}
-      aria-invalid={hasError || undefined}
-      required
-      {...props}
-    />
-  </>
-)
+export const Input: React.FC<InputProps> = ({ id, label, ...props }) => {
+  const field = useErrorContext()
+  const hasError = field.hasError(id)
+
+  return (
+    <>
+      {label && (<label htmlFor={id}>{label}:</label>)}
+      <input
+        className={styles.input}
+        id={id}
+        name={id}
+        type="text"
+        inputMode="tel"
+        autoComplete={id.replace(/_/g, "-")}
+        aria-describedby={hasError ? `aria_errorlist err_${id}` : undefined}
+        aria-invalid={hasError || undefined}
+        required
+        {...props}
+      />
+    </>
+  )
+}
 
 export const ExpiryDate: React.FC<ExpiryDateProps> = ({ className, month, year }) => (
   <fieldset className={className || styles.cc_exp}>
@@ -28,41 +34,37 @@ export const ExpiryDate: React.FC<ExpiryDateProps> = ({ className, month, year }
   </fieldset>
 )
 
-export const CardNumber: React.FC<FixedInputProps> = ({ className, hasError }) => (
+export const CardNumber: React.FC<FixedInputProps> = ({ className }) => (
   <div className={className || styles.cc_number}>
     <Input
       id="cc_number"
       label="Card Number"
-      hasError={hasError("cc_number")}
     />
   </div>
 )
 
-export const ExpMonth: React.FC<FixedInputProps> = ({ hasError }) => (
+export const ExpMonth: React.FC<FixedInputProps> = () => (
   <Input
     id="cc_exp_month"
     aria-label="Month, Format: 2 digits."
     maxLength={2}
-    hasError={hasError("cc_exp_month")}
   />
 )
 
-export const ExpYear: React.FC<FixedInputProps> = ({ hasError }) => (
+export const ExpYear: React.FC<FixedInputProps> = () => (
   <Input
     id="cc_exp_year"
     aria-label="Year, Format: 2 digits."
     maxLength={2}
-    hasError={hasError("cc_exp_year")}
   />
 )
 
-export const SecurityCode: React.FC<FixedInputProps> = ({ className, hasError }) => (
+export const SecurityCode: React.FC<FixedInputProps> = ({ className }) => (
   <div className={className || styles.cc_csc}>
     <Input
       id="cc_csc"
       label="Security Code"
       maxLength={4}
-      hasError={hasError("cc_csc")}
     />
   </div>
 )
@@ -70,7 +72,6 @@ export const SecurityCode: React.FC<FixedInputProps> = ({ className, hasError })
 type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   id: keyof CreditCard
   label?: string
-  hasError?: boolean
 }
 
 type ExpiryDateProps = {
@@ -81,7 +82,6 @@ type ExpiryDateProps = {
 
 type FixedInputProps = {
   className?: string
-  hasError: (id: keyof CreditCard) => boolean | undefined
 }
 
 export default Input

--- a/src/components/cc-form/index.tsx
+++ b/src/components/cc-form/index.tsx
@@ -17,14 +17,8 @@ export const Form = () => {
     <div className={styles.formWrapper}>
       <form className={styles.form} onSubmit={handleSubmit(onValid, onInvalid)}>
         <Inputs.CardNumber />
-
-        <Inputs.ExpiryDate
-          month={<Inputs.ExpMonth />}
-          year ={<Inputs.ExpYear  />}
-        />
-
+        <Inputs.ExpiryDate month={<Inputs.ExpMonth />} year={<Inputs.ExpYear />} />
         <Inputs.SecurityCode />
-
         <Submit className={styles.submit} hasErrors={hasErrors} />
       </form>
 

--- a/src/components/cc-form/index.tsx
+++ b/src/components/cc-form/index.tsx
@@ -1,39 +1,41 @@
 import styles from './styles.module.scss'
 import { Error, Inputs, Submit } from './components'
 import { CreditCard } from './schema'
-import { useForm, onValid, onInvalid } from './submitLogic'
+import { useForm, onValid, onInvalid, ErrorContext } from './submitLogic'
 
 export const Form = () => {
   const {
     handleSubmit,
-    formState: { errors, isValid, isSubmitted },
+    formState: { isValid, isSubmitted },
+    errorMethods,
   } = useForm<CreditCard>()
 
-  const hasError = (id: keyof CreditCard) => errors?.issues.some(err => err.path.includes(id))
   const hasErrors = isSubmitted && !isValid
 
   return (
+    <ErrorContext.Provider value={errorMethods}>
     <div className={styles.formWrapper}>
       <form className={styles.form} onSubmit={handleSubmit(onValid, onInvalid)}>
-        <Inputs.CardNumber hasError={hasError} />
+        <Inputs.CardNumber />
 
         <Inputs.ExpiryDate
-          month={<Inputs.ExpMonth hasError={hasError} />}
-          year ={<Inputs.ExpYear  hasError={hasError} />}
+          month={<Inputs.ExpMonth />}
+          year ={<Inputs.ExpYear  />}
         />
 
-        <Inputs.SecurityCode hasError={hasError} />
+        <Inputs.SecurityCode />
 
         <Submit className={styles.submit} hasErrors={hasErrors} />
       </form>
 
       <Error.List className={styles.errors} hasErrors={hasErrors}>
-        <Error.Item id="cc_number"    label="Card Number"   errors={errors} />
-        <Error.Item id="cc_exp_month" label="Expiry Month"  errors={errors} />
-        <Error.Item id="cc_exp_year"  label="Expiry Year"   errors={errors} />
-        <Error.Item id="cc_csc"       label="Security Code" errors={errors} />
+        <Error.Item id="cc_number"    label="Card Number"   />
+        <Error.Item id="cc_exp_month" label="Expiry Month"  />
+        <Error.Item id="cc_exp_year"  label="Expiry Year"   />
+        <Error.Item id="cc_csc"       label="Security Code" />
       </Error.List>
     </div>
+    </ErrorContext.Provider>
   )
 }
 


### PR DESCRIPTION
The error prop drilling seemed a bit repetitive/noisy, attempted to DRY that up with a context instead to access the shared error state.