### PR TITLE
fix: Provide schema as param to `useForm<T>`, resolving the typing issues

### DIFF
--- a/src/components/cc-form/index.tsx
+++ b/src/components/cc-form/index.tsx
@@ -1,14 +1,15 @@
 import styles from './styles.module.scss'
 import { Error, Inputs, Submit } from './components'
-import { CreditCard } from './schema'
-import { useForm, onValid, onInvalid, ErrorContext } from './submitLogic'
+import schema, { CreditCard } from './schema'
+import { useForm, ErrorContext } from './submitLogic'
+import { ZodError } from 'zod'
 
 export const Form = () => {
   const {
     handleSubmit,
     formState: { isValid, isSubmitted },
     errorMethods,
-  } = useForm<CreditCard>()
+  } = useForm<CreditCard>(schema)
 
   const hasErrors = isSubmitted && !isValid
 
@@ -17,7 +18,10 @@ export const Form = () => {
     <div className={styles.formWrapper}>
       <form className={styles.form} onSubmit={handleSubmit(onValid, onInvalid)}>
         <Inputs.CardNumber />
-        <Inputs.ExpiryDate month={<Inputs.ExpMonth />} year={<Inputs.ExpYear />} />
+        <Inputs.ExpiryDate
+          month={<Inputs.ExpMonth />}
+          year ={<Inputs.ExpYear  />}
+        />
         <Inputs.SecurityCode />
         <Submit className={styles.submit} hasErrors={hasErrors} />
       </form>
@@ -31,6 +35,38 @@ export const Form = () => {
     </div>
     </ErrorContext.Provider>
   )
+}
+
+
+function onInvalid(error: ZodError) {
+  console.error(
+    "Submission Failure:\n",
+    error.issues
+  )
+
+  // Lists validation errors (value array) grouped by each form field (key)
+  Object.entries(error.flatten().fieldErrors).forEach(([k, v]) => {
+    console.warn(k, v)
+  })
+  // These errors relate to post-processing the data object,
+  // after initial validation of each individual fields type passes:
+  Object.entries(error.flatten().formErrors).forEach(([k, v]) => {
+    console.warn(k, v)
+  })
+}
+
+function onValid(data: CreditCard) {
+  const expiry_date = `${data.cc_exp_month} / ${data.cc_exp_year}`
+
+  // Remap to nicer object keys for viewing in console:
+  console.log("Submission Successful!")
+  console.log({
+    card_number: data.cc_number,
+    security_code: data.cc_csc,
+    expiry_date,
+  })
+
+  // Do stuff... like post to an endpoint
 }
 
 export default Form

--- a/src/components/cc-form/submitLogic.ts
+++ b/src/components/cc-form/submitLogic.ts
@@ -1,12 +1,11 @@
 import { useState, createContext, useContext } from 'react'
-import { ZodError } from 'zod'
-import schema, { CreditCard } from './schema'
+import { ZodError, ZodSchema } from 'zod'
 
 export const ErrorContext = createContext<any>(undefined)
 export const useErrorContext = () => useContext(ErrorContext)
 
 function useErrorStatus<T>() {
-  const [errors, setErrors] = useState<ZodError | undefined>();
+  const [errors, setErrors] = useState<ZodError<T> | undefined>();
   const hasError = (id: keyof T & string) => errors?.issues.some(err => err.path.includes(id))
   const getError = (id: keyof T & string) => errors?.issues.filter(err => err.path.includes(id))[0]
 
@@ -16,16 +15,7 @@ function useErrorStatus<T>() {
   }
 }
 
-// I could not make TS happy for _onValid with generic type `T` due to TS2345
-// Used `T | any` until I have a better grasp of TS.
-type onSubmit<T> = (
-  _onValid: (data: T | any) => void,
-  _onInvalid: (error: ZodError) => void
-) => (e: React.FormEvent<HTMLFormElement>) => void
-
-// Again had some TS typing issues with `useState()`. The error object doesn't exist initially,
-// also accepting `undefined` seems to fix it, unclear if that's advised?
-function useForm<T>() {
+function useForm<T>(schema: ZodSchema<T, any, any>) {
   const { setErrors, fieldMethods } = useErrorStatus<T>()
   const [isSubmitted, setSubmitStatus] = useState(false)
   const [isValid, setValid] = useState(false)
@@ -58,35 +48,9 @@ function useForm<T>() {
   }
 }
 
-function onInvalid(error: ZodError) {
-  console.error(
-    "Submission Failure:\n",
-    error.issues
-  )
+type onSubmit<T> = (
+  _onValid: (data: T) => void,
+  _onInvalid: (error: ZodError<T>) => void
+) => (e: React.FormEvent<HTMLFormElement>) => void
 
-  // Lists validation errors (value array) grouped by each form field (key)
-  Object.entries(error.flatten().fieldErrors).forEach(([k, v]) => {
-    console.warn(k, v)
-  })
-  // These errors relate to post-processing the data object,
-  // after initial validation of each individual fields type passes:
-  Object.entries(error.flatten().formErrors).forEach(([k, v]) => {
-    console.warn(k, v)
-  })
-}
-
-function onValid(data: CreditCard) {
-  const expiry_date = `${data.cc_exp_month} / ${data.cc_exp_year}`
-
-  // Remap to nicer object keys for viewing in console:
-  console.log("Submission Successful!")
-  console.log({
-    card_number: data.cc_number,
-    security_code: data.cc_csc,
-    expiry_date,
-  })
-
-  // Do stuff... like post to an endpoint
-}
-
-export { useForm, onValid, onInvalid }
+export { useForm }


### PR DESCRIPTION
It seems the type issues faced earlier were due importing my specific schema, which technically prevented a generic type alias... for some reason that didn't occur to me at the time :sweat_smile: 

By passing it in as a parameter I can ensure the schema and it's `<output>` (_data returned after validation, not prior input type_) type match. This enables `T` to be passed to ZodError and remove the `| any` union type I had on the `_onValid` data arg :grinning: 

This submission hook logic is no longer tied to this component and can later be extracted out of it as a generic method/hook :tada: 

As such the two complimentary `onValid()` + `onInvalid()` methods that were exported have migrated back into the main form component that they're specific to.